### PR TITLE
fix getting file name when path contains :

### DIFF
--- a/lib/capistrano/cluster/files.rb
+++ b/lib/capistrano/cluster/files.rb
@@ -39,8 +39,8 @@ module Capistrano
         end
 
         def item(identifier)
-          consume = false
-          xml = File.read(caller.first.split(":").first).lines.select { |l| consume ||= l =~/^__END__$/ || consume}[1..-1].join()
+          consume = false          
+          xml = File.read(caller.first.match(/(?<file>.*):(?<line_number>\d+):/)["file"]).lines.select { |l| consume ||= l =~/^__END__$/ || consume}[1..-1].join()
           doc = Nokogiri::HTML(xml)
           doc.css("##{identifier}").inner_html
         end


### PR DESCRIPTION
When deploying on windows, path names contains :, rewritten using regexp.
